### PR TITLE
Remove scrollTo method from download page

### DIFF
--- a/panel-download.html
+++ b/panel-download.html
@@ -228,7 +228,3 @@ Note: All the files can be downloaded via <a href="https://download.electrum.org
     Old versions of Windows might need to install the KB2999226 Windows update.
   </p>
 </div>
-
-<script type="text/javascript" charset="utf-8">
-    window.scrollTo(0,0);
-</script>


### PR DESCRIPTION
the scrollTo method isn't supported by Tor's NoScript and therefore the download page isn't accessible to Tor users and some obscure browsers with similar implementations. By removing this, the download page is once again accessible for those users.