### PR TITLE
make release process operate on file triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 ._*.*
 talks/
 .idea/
+
+trigger_website
+trigger_binaries

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,80 +3,102 @@
 set -ex
 
 REPODIR="$(dirname "$(readlink -e "$0")")"
-cd "$REPODIR"
 
 date -u
 
-# fixme: we should not poll github
-git fetch github
-LOCAL_COMMIT="$(git rev-parse master)"
-REMOTE_COMMIT="$(git rev-parse github/master)"
-
-if [ $LOCAL_COMMIT = $REMOTE_COMMIT ];
-then
-    echo "no changes, exiting"
-    exit 0
-fi
-
-LOCAL_VERSION=$(cat version|jq '.version'|tr -d '"')
-VERSION=$(git show github/master:version|jq '.version'|tr -d '"')
-
-echo "local version: $LOCAL_VERSION "
-echo "github version: $VERSION "
-
-sftp -oBatchMode=no -b - pubwww@uploadserver << !
-   cd electrum-downloads-airlock
-   get website.ThomasV.asc
-   get website.sombernight_releasekey.asc
-   bye
-!
-
-git rev-parse github/master | gpg --no-default-keyring --keyring "$REPODIR/gpg/thomasv.gpg" --verify website.ThomasV.asc -
-git rev-parse github/master | gpg --no-default-keyring --keyring "$REPODIR/gpg/sombernight_releasekey.gpg" --verify website.sombernight_releasekey.asc -
-
-echo "website signature verified"
-# Update website immediately (in case the rest of the script crashes)
-git merge --ff-only FETCH_HEAD
-
-
-# Read from the airlock directory
 rm -rf /tmp/airlock
 mkdir /tmp/airlock
-pushd /tmp/airlock
+cd /tmp/airlock
 
 sftp -oBatchMode=no -b - pubwww@uploadserver << !
    cd electrum-downloads-airlock
-   cd $VERSION
-   mget *
+   -get trigger_website
+   -rm trigger_website
+   -get trigger_binaries
+   -rm trigger_binaries
    bye
 !
 
-# verify signatures of binaries
-for item in ./*
-do
-    if [[ "$item" == *".asc" ]]; then
-        :  # skip verifying signature-files
+# Maybe update website.
+# This could also update this script itself (but only for subsequent runs!)
+if [ -f trigger_website ]; then
+    echo "file trigger found: trigger_website."
+    cd "$REPODIR"
+    git fetch github
+    LOCAL_COMMIT="$(git rev-parse master)"
+    REMOTE_COMMIT="$(git rev-parse github/master)"
+
+    if [ "$LOCAL_COMMIT" = "$REMOTE_COMMIT" ]; then
+        echo "no changes for website."
     else
-        # All other files should be reproducible binaries; verify two sigs.
-        # In case we upload any other file for whatever reason, both sigs are needed too.
-        gpg --no-default-keyring --keyring "$REPODIR/gpg/thomasv.gpg" --verify "$item.ThomasV.asc" "$item"
-        gpg --no-default-keyring --keyring "$REPODIR/gpg/sombernight_releasekey.gpg" --verify "$item.sombernight_releasekey.asc" "$item"
-        # create aggregated signature file
-        cat $item.*.asc > "$item.asc"
-    fi
-done
+        echo "found some changes for website."
 
-echo "verification passed"
-
-# publish files
-sftp -oBatchMode=no -b - pubwww@uploadserver << !
-   cd electrum-downloads
-   -mkdir $VERSION
-   cd $VERSION
-   mput *
-   bye
+        sftp -oBatchMode=no -b - pubwww@uploadserver << !
+            cd electrum-downloads-airlock
+            get website.ThomasV.asc
+            get website.sombernight_releasekey.asc
+            bye
 !
 
-popd
+        git rev-parse github/master | gpg --no-default-keyring --keyring "$REPODIR/gpg/thomasv.gpg" --verify website.ThomasV.asc -
+        git rev-parse github/master | gpg --no-default-keyring --keyring "$REPODIR/gpg/sombernight_releasekey.gpg" --verify website.sombernight_releasekey.asc -
+
+        echo "website signature verified"
+        # Update website immediately (in case the rest of the script crashes)
+        git merge --ff-only FETCH_HEAD
+    fi
+else
+    echo "file trigger NOT found: trigger_website."
+fi
+
+
+# Maybe upload binaries.
+cd /tmp/airlock
+if [ ! -f trigger_binaries ] || [ ! -s trigger_binaries ]; then
+    echo "file trigger NOT found or is empty: trigger_binaries."
+else
+    echo "file trigger found: trigger_binaries."
+    TRIGGERVERSION="$(cat trigger_binaries)"
+    echo "TRIGGERVERSION: $TRIGGERVERSION"
+
+    # Read binaries/etc from the airlock directory, based on TRIGGERVERSION
+    rm -rf /tmp/airlock
+    mkdir /tmp/airlock
+    cd /tmp/airlock
+
+    sftp -oBatchMode=no -b - pubwww@uploadserver << !
+       cd electrum-downloads-airlock
+       cd "$TRIGGERVERSION"
+       mget *
+       bye
+!
+
+    # verify signatures of binaries
+    for item in ./*
+    do
+        if [[ "$item" == *".asc" ]]; then
+            :  # skip verifying signature-files
+        else
+            # All other files should be reproducible binaries; verify two sigs.
+            # In case we upload any other file for whatever reason, both sigs are needed too.
+            gpg --no-default-keyring --keyring "$REPODIR/gpg/thomasv.gpg" --verify "$item.ThomasV.asc" "$item"
+            gpg --no-default-keyring --keyring "$REPODIR/gpg/sombernight_releasekey.gpg" --verify "$item.sombernight_releasekey.asc" "$item"
+            # create aggregated signature file
+            cat $item.*.asc > "$item.asc"
+        fi
+    done
+
+    echo "verification passed"
+
+    # publish files
+    sftp -oBatchMode=no -b - pubwww@uploadserver << !
+       cd electrum-downloads
+       -mkdir "$TRIGGERVERSION"
+       cd "$TRIGGERVERSION"
+       -mput *
+       bye
+!
+
+fi
 
 # todo: clear cloudflare cache

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # sign website commit and publish it
 # uploadserver needs to be defined in /etc/hosts
 
@@ -24,5 +25,6 @@ git rev-parse master | gpg --sign --armor --detach $PUBKEY > website.$GPGUSER.as
 sftp -oBatchMode=no -b - ${SSHUSER}@uploadserver << !
    cd electrum-downloads-airlock
    mput website.$GPGUSER.asc
+   mput trigger_website
    bye
 !


### PR DESCRIPTION
Instead of polling github for website git repo updates and tying binaries crossing the airlock to them, file triggers are introduced to be able to independently update the website or upload binaries.

This allows the add_cosigner workflow to be done before the website links to new binaries.