### PR TITLE
updated links for gpg verification info

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,8 +247,8 @@ Note: All the files can be downloaded via <a href="https://download.electrum.org
     ThomasV's <a href="https://raw.githubusercontent.com/spesmilo/electrum/master/pubkeys/ThomasV.asc">public
     key</a>. On Linux, you can import that key using the following
     command: <code>gpg --import ThomasV.asc</code>. Here are tutorials for
-    <a href="https://bitzuma.com/posts/how-to-verify-an-electrum-download-on-windows/">Windows</a>
-    and <a href="https://bitzuma.com/posts/how-to-verify-an-electrum-download-on-mac/">macOS</a>.
+    <a href="https://bitcoinelectrum.com/how-to-verify-your-electrum-download/">Windows</a>
+    and <a href="https://gist.github.com/rosswd/c49f663eb813869620164e3695829e9b">macOS</a>.
     When you import a key, you should check its fingerprint using
     independent sources, such
     as <a href="https://www.youtube.com/watch?v=hjYCXOyDy7Y">here</a>,


### PR DESCRIPTION
the bitzuma site appears to be gone (or at least down at tis time). i found some new links and dropped them in.